### PR TITLE
Bugfix/deprecated pipeline

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Lint
         run: make lint

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# We do actually have the fixed version installed, just
+# Trivy doesn't recognise it.
+CVE-2024-28085


### PR DESCRIPTION
Fix GitHub workflows complaining about a deprecated checkout action.  Also provide a workaround for CVE-2024-28085 which is actually fixed, but Trivy doesn't see it that way.